### PR TITLE
Add regVersion option to specify 32 or 64 bit registry

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -39,7 +39,10 @@ var util          = require('util')
 /* registry item pattern */
 ,   ITEM_PATTERN  = /^([a-zA-Z0-9_\s\\-]+)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
 
-
+/* registry versions */
+,   REG_32_BITS = '/REG:32'
+,   REG_64_BITS = '/REG:64' 
+,   REG_VERSIONS = [ REG_32_BITS, REG_64_BITS ]
 
 /**
  * a single registry value record
@@ -88,12 +91,14 @@ function Registry (options) {
   var _options = options || {}
   ,   _host = '' + (_options.host || '')    // hostname
   ,   _hive = '' + (_options.hive || HKLM)  // registry hive
-  ,   _key  = '' + (_options.key  || '')    // registry key
+  ,   _key  = '' + (_options.key  || '')  // registry key
+  ,   _regVersion = _options.regVersion ? '/REG:' + _options.regVersion : ''; // registry Version - 32 or 64
 
   /* getters/setters */
   this.__defineGetter__('host', function () { return _host; });
   this.__defineGetter__('hive', function () { return _hive; });
   this.__defineGetter__('key', function () { return _key; });
+  this.__defineGetter__('regVersion', function () { return _regVersion; });
   this.__defineGetter__('path', function () { return (_host.length == 0 ? '' : '\\\\' + host + '\\') + _hive + _key; });
   this.__defineGetter__('parent', function () {
     var i = _key.lastIndexOf('\\')
@@ -110,6 +115,9 @@ function Registry (options) {
 
   if (!KEY_PATTERN.test(_key))
     throw new Error('illegal key specified.');
+  
+  if (_options.regVersion && REG_VERSIONS.indexOf(_regVersion) === -1)
+    throw new Error('illegal regVersion specified.');
 
   Object.freeze(this);
 }
@@ -194,7 +202,7 @@ Registry.prototype.values = function values (cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = [ 'QUERY', this.path ]
+  var args = [ 'QUERY', this.path, this.regVersion ]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
@@ -260,7 +268,7 @@ Registry.prototype.keys = function keys (cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = [ 'QUERY', this.path ]
+  var args = [ 'QUERY', this.path, this.regVersion ]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
@@ -328,7 +336,7 @@ Registry.prototype.get = function get (name, cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = [ 'QUERY', this.path, '/v', name ]
+  var args = [ 'QUERY', this.path, '/v', name, this.regVersion ]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,


### PR DESCRIPTION
Add regVersion option in order to specify 32 or 64 bits is the key. Corresponds to REG's /REG:32 and /REG:64 options. Add validation that passed value is 32 or 64. If value is not passed, regVersion is not passed to REG command line tool.
Should be used in the following way:

var Winreg = require('winreg')
,   regKey = new Winreg({
      hive: Winreg.HKLM,                                          // HKEY_CURRENT_USER
      key: '\\Software\\Microsoft\\Windows\\CurrentVersion\\Run', // key containing autostart programs
      regVersion: '32',  // if you specify 64 you'll see different result
    })